### PR TITLE
Change key bindings to cope with org-clock shortcut

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -19,7 +19,7 @@
     :defer t
     :commands (cfw:open-calendar-buffer)
     :init
-    (spacemacs/set-leader-keys "aC" 'cfw:open-calendar-buffer)
+    (spacemacs/set-leader-keys "aCd" 'cfw:open-calendar-buffer)
     :config
     (progn
       (define-key cfw:calendar-mode-map (kbd "SPC") 'spacemacs-cmds)
@@ -33,7 +33,7 @@
     :defer t
     :commands (cfw:open-org-calendar)
     :init
-    (spacemacs/set-leader-keys "aoC" 'cfw:open-org-calendar)
+    (spacemacs/set-leader-keys "aoCd" 'cfw:open-org-calendar)
     :config
     (progn
       (define-key cfw:org-schedule-map (kbd "SPC") 'spacemacs-cmds)


### PR DESCRIPTION
Spacemacs give aoC as s clock submenu. This change moves the keyboard shortcut to be a sub command of that one.

It might make more sense to be "aoD" or maybe "aog" ( g for google calendar? ) but this fixes the error that I have. :)